### PR TITLE
Implement support for 'SupportsShouldProcess'

### DIFF
--- a/source/public/Get-EasitGODatasource.ps1
+++ b/source/public/Get-EasitGODatasource.ps1
@@ -52,7 +52,7 @@ function Get-EasitGODatasource {
         [PSCustomObject](https://learn.microsoft.com/en-us/dotnet/api/system.management.automation.pscustomobject)
     #>
     [OutputType('PSCustomObject')]
-    [CmdletBinding(HelpUri = 'https://docs.easitgo.com/techspace/psmodules/gowebservice/functions/geteasitgodatasource/')]
+    [CmdletBinding(HelpUri = 'https://docs.easitgo.com/techspace/psmodules/gowebservice/functions/geteasitgodatasource/', SupportsShouldProcess)]
     param (
         [Parameter(Mandatory)]
         [string]$Url,
@@ -111,27 +111,31 @@ function Get-EasitGODatasource {
         } catch {
             throw $_
         }
-        if ($null -eq $InvokeRestMethodParameters) {
-            try {
-                $response = Invoke-EasitGOWebRequest -BaseParameters $baseRMParams
-            } catch {
-                throw $_
+        if ($PSCmdlet.ShouldProcess($baseRMParams.Uri)) {
+            if ($null -eq $InvokeRestMethodParameters) {
+                try {
+                    $response = Invoke-EasitGOWebRequest -BaseParameters $baseRMParams
+                } catch {
+                    throw $_
+                }
+            } else {
+                try {
+                    $response = Invoke-EasitGOWebRequest -BaseParameters $baseRMParams -CustomParameters $InvokeRestMethodParameters
+                } catch {
+                    throw $_
+                }
+            }
+            if ($ReturnAsSeparateObjects) {
+                try {
+                    Convert-EasitGODatasourceResponse -Response $response
+                } catch {
+                    throw $_
+                }
+            } else {
+                return $response
             }
         } else {
-            try {
-                $response = Invoke-EasitGOWebRequest -BaseParameters $baseRMParams -CustomParameters $InvokeRestMethodParameters
-            } catch {
-                throw $_
-            }
-        }
-        if ($ReturnAsSeparateObjects) {
-            try {
-                Convert-EasitGODatasourceResponse -Response $response
-            } catch {
-                throw $_
-            }
-        } else {
-            return $response
+            # No data should be sent to URL when -WhatIf is used.
         }
     }
     end {

--- a/source/public/Get-EasitGOItem.ps1
+++ b/source/public/Get-EasitGOItem.ps1
@@ -138,7 +138,7 @@ function Get-EasitGOItem {
     #>
     [OutputType('PSCustomObject')]
     [Alias('Get-GOItems')]
-    [CmdletBinding(DefaultParameterSetName = 'OneObject', HelpUri = 'https://docs.easitgo.com/techspace/psmodules/gowebservice/functions/geteasitgoitem/')]
+    [CmdletBinding(DefaultParameterSetName = 'OneObject', HelpUri = 'https://docs.easitgo.com/techspace/psmodules/gowebservice/functions/geteasitgoitem/', SupportsShouldProcess)]
     param (
         [Parameter(Mandatory,ParameterSetName='OneObject')]
         [Parameter(Mandatory,ParameterSetName='SeparateObjects')]
@@ -238,78 +238,82 @@ function Get-EasitGOItem {
         } catch {
             throw $_
         }
-        if ($null -eq $InvokeRestMethodParameters) {
-            try {
-                $response = Invoke-EasitGOWebRequest -BaseParameters $baseRMParams
-            } catch {
-                throw $_
-            }
-        } else {
-            try {
-                $response = Invoke-EasitGOWebRequest -BaseParameters $baseRMParams -CustomParameters $InvokeRestMethodParameters
-            } catch {
-                throw $_
-            }
-        }
-        if ($ReturnAsSeparateObjects) {
-            $cgirParams = @{
-                Response = $response
-                FlatReturnObject = $FlatReturnObject
-                ThrottleLimit = $ThrottleLimit
-            }
-            try {
-                Convert-GetItemsResponse @cgirParams
-            } catch {
-                throw $_
-            }
-        } else {
-            Write-Output $response
-        }
-        $currentPage = $response.requestedPage
-        $lastPage = $response.totalNumberOfPages
-        if ($GetAllPages) {
-            $currentPage++
-            do {
-                $response = $null
+        if ($PSCmdlet.ShouldProcess($baseRMParams.Uri)) {
+            if ($null -eq $InvokeRestMethodParameters) {
                 try {
-                    $newGetEasitGOItemsRequestBodyParams.Page = $currentPage
+                    $response = Invoke-EasitGOWebRequest -BaseParameters $baseRMParams
                 } catch {
                     throw $_
                 }
+            } else {
                 try {
-                    $baseRMParams.Body = New-GetEasitGOItemsRequestBody @newGetEasitGOItemsRequestBodyParams
+                    $response = Invoke-EasitGOWebRequest -BaseParameters $baseRMParams -CustomParameters $InvokeRestMethodParameters
                 } catch {
                     throw $_
                 }
-                if ($null -eq $InvokeRestMethodParameters) {
-                    try {
-                        $response = Invoke-EasitGOWebRequest -BaseParameters $baseRMParams
-                    } catch {
-                        throw $_
-                    }
-                } else {
-                    try {
-                        $response = Invoke-EasitGOWebRequest -BaseParameters $baseRMParams -CustomParameters $InvokeRestMethodParameters
-                    } catch {
-                        throw $_
-                    }
+            }
+            if ($ReturnAsSeparateObjects) {
+                $cgirParams = @{
+                    Response = $response
+                    FlatReturnObject = $FlatReturnObject
+                    ThrottleLimit = $ThrottleLimit
                 }
-                if ($ReturnAsSeparateObjects) {
-                    $cgirParams = @{
-                        Response = $response
-                        FlatReturnObject = $FlatReturnObject
-                        ThrottleLimit = $ThrottleLimit
-                    }
-                    try {
-                        Convert-GetItemsResponse @cgirParams
-                    } catch {
-                        throw $_
-                    }
-                } else {
-                    Write-Output $response
+                try {
+                    Convert-GetItemsResponse @cgirParams
+                } catch {
+                    throw $_
                 }
+            } else {
+                Write-Output $response
+            }
+            $currentPage = $response.requestedPage
+            $lastPage = $response.totalNumberOfPages
+            if ($GetAllPages) {
                 $currentPage++
-            } while ($currentPage -le $lastPage)
+                do {
+                    $response = $null
+                    try {
+                        $newGetEasitGOItemsRequestBodyParams.Page = $currentPage
+                    } catch {
+                        throw $_
+                    }
+                    try {
+                        $baseRMParams.Body = New-GetEasitGOItemsRequestBody @newGetEasitGOItemsRequestBodyParams
+                    } catch {
+                        throw $_
+                    }
+                    if ($null -eq $InvokeRestMethodParameters) {
+                        try {
+                            $response = Invoke-EasitGOWebRequest -BaseParameters $baseRMParams
+                        } catch {
+                            throw $_
+                        }
+                    } else {
+                        try {
+                            $response = Invoke-EasitGOWebRequest -BaseParameters $baseRMParams -CustomParameters $InvokeRestMethodParameters
+                        } catch {
+                            throw $_
+                        }
+                    }
+                    if ($ReturnAsSeparateObjects) {
+                        $cgirParams = @{
+                            Response = $response
+                            FlatReturnObject = $FlatReturnObject
+                            ThrottleLimit = $ThrottleLimit
+                        }
+                        try {
+                            Convert-GetItemsResponse @cgirParams
+                        } catch {
+                            throw $_
+                        }
+                    } else {
+                        Write-Output $response
+                    }
+                    $currentPage++
+                } while ($currentPage -le $lastPage)
+            }
+        } else {
+            # No data should be sent to URL when -WhatIf is used.
         }
     }
     end {

--- a/tests/module/Get-EasitGODatasource.Tests.ps1
+++ b/tests/module/Get-EasitGODatasource.Tests.ps1
@@ -54,4 +54,8 @@ Describe "Get-EasitGODatasource" -Tag 'module' {
         $output = Get-EasitGODatasource -Url $url -Apikey $api -ModuleId 1001 -ReturnAsSeparateObjects
         $output.Count | Should -BeExactly 4
     }
+    It 'should not return anything when -WhatIf is used' {
+        $output = Get-EasitGODatasource -Url $url -Apikey $api -ModuleId 1001 -ReturnAsSeparateObjects -WhatIf
+        $output | Should -BeNullOrEmpty
+    }
 }

--- a/tests/module/Get-EasitGOImportClientConfiguration.Tests.ps1
+++ b/tests/module/Get-EasitGOImportClientConfiguration.Tests.ps1
@@ -114,4 +114,8 @@ Describe "Get-EasitGOImportClientConfiguration" -Tag 'function','public' {
         $config.identifier | Should -BeExactly 'fileConfiguration'
         $config.sleepBetweenPostings | Should -BeExactly 1
     }
+    It 'should not return anything when -WhatIf is used' {
+        $output = Get-EasitGOImportClientConfiguration @getFromEasitParamsFile -WhatIf
+        $output | Should -BeNullOrEmpty
+    }
 }

--- a/tests/module/Get-EasitGOItem.Tests.ps1
+++ b/tests/module/Get-EasitGOItem.Tests.ps1
@@ -101,4 +101,8 @@ Describe "Get-EasitGOItem" -Tag 'module' {
         $output = Get-EasitGOItem -Url $url -Apikey $api -ImportViewIdentifier $ImportViewIdentifier -ReturnAsSeparateObjects
         $output.Count | Should -BeExactly 25
     }
+    It 'should not return anything when -WhatIf is used' {
+        $output = Get-EasitGOItem -Url $url -Apikey $api -ImportViewIdentifier $ImportViewIdentifier -ReturnAsSeparateObjects -WhatIf
+        $output | Should -BeNullOrEmpty
+    }
 }

--- a/tests/module/Send-ToEasitGO.Tests.ps1
+++ b/tests/module/Send-ToEasitGO.Tests.ps1
@@ -93,4 +93,8 @@ Describe "Send-ToEasitGO" -Tag 'module' {
         $output = Send-ToEasitGO @sendItemParams -Item $1000Items -SendInBatchesOf 75
         $output[0].itemToImport.Count | Should -BeExactly 75
     }
+    It 'should not return anything when -WhatIf is used' {
+        $output = Send-ToEasitGO @sendItemParams -Item $1000Items -SendInBatchesOf 75 -WhatIf
+        $output | Should -BeNullOrEmpty
+    }
 }


### PR DESCRIPTION
This pull request implement support for 'SupportsShouldProcess' giving the user the option to use the -WhatIf parameter.

This parameter act as a safe guard and could be used for "dry running" the function.

Implemented in:
* Get-EasitGODatasource
* Get-EasitGOItem
* Send-ToEasitGO
* Get-EasitGOImportClientConfiguration