### PR TITLE
Add option for writing request body to file

### DIFF
--- a/source/private/Write-StringToFile.ps1
+++ b/source/private/Write-StringToFile.ps1
@@ -1,0 +1,60 @@
+function Write-StringToFile {
+    <#
+    .SYNOPSIS
+        Sends a string to a file.
+    .DESCRIPTION
+        The **Write-StringToFile** function sends a string to a file. If the file already exists a new file with a higher index number (following the naming format \[FilenamePrefix\]_payload_indexNumber.txt) will be created.
+    .EXAMPLE
+        Write-StringToFile -InputString $baseRMParams.Body -FilenamePrefix 'GetEasitGOItem'
+    .EXAMPLE
+        Write-StringToFile -InputString $baseRMParams.Body -FilenamePrefix 'SendToEasitGO'
+    .PARAMETER InputString
+        String to write to a file.
+    .PARAMETER FilenamePrefix
+        Prefix to set prepend to *_payload_indexNumber.txt*. If not prefix is provided, file name will be *payload_indexNumber.txt*.
+    .OUTPUTS
+        None - This function returns no output.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [String]$InputString,
+        [Parameter()]
+        [String]$FilenamePrefix
+    )
+    begin {
+        Write-Verbose "$($MyInvocation.MyCommand) initialized"
+    }
+    process {
+        $i = 1
+        $currentDirectory = Get-Location
+        if ([String]::IsNullOrWhiteSpace($FilenamePrefix)) {
+            $baseFilename = 'payload'
+        } else {
+            $baseFilename = "${FilenamePrefix}_payload"
+        }
+        do {
+            $outputFileName = "${baseFilename}_$i.txt"
+            $payloadFile = Join-Path -Path $currentDirectory -ChildPath "$outputFileName"
+            if (Test-Path $payloadFile) {
+                    $i++
+            }
+        } until (!(Test-Path $payloadFile))
+        if (!(Test-Path $payloadFile)) {
+            try {
+                $outFileParams = @{
+                    FilePath = "$payloadFile"
+                    Encoding = 'utf8NoBOM'
+                    Force = $true
+                }
+                $InputString | Out-File @outFileParams
+            }
+            catch {
+                throw $_
+            }
+        }
+    }
+    end {
+        Write-Verbose "$($MyInvocation.MyCommand) completed"
+    }
+}

--- a/source/public/Get-EasitGODatasource.ps1
+++ b/source/public/Get-EasitGODatasource.ps1
@@ -68,7 +68,9 @@ function Get-EasitGODatasource {
         [Parameter()]
         [Switch]$ReturnAsSeparateObjects,
         [Parameter()]
-        [System.Collections.Hashtable]$ConvertToJsonParameters
+        [System.Collections.Hashtable]$ConvertToJsonParameters,
+        [Parameter()]
+        [Switch]$WriteBody
     )
     begin {
         Write-Verbose "$($MyInvocation.MyCommand) initialized"
@@ -110,6 +112,13 @@ function Get-EasitGODatasource {
             $baseRMParams.Body = New-GetEasitGODatasourceRequestBody @newGetEasitGODatasourceRequestBodyParams
         } catch {
             throw $_
+        }
+        if ($WriteBody) {
+            try {
+                Write-StringToFile -InputString $baseRMParams.Body -FilenamePrefix 'GetEasitGODatasource'
+            } catch {
+                Write-Warning $_
+            }
         }
         if ($PSCmdlet.ShouldProcess($baseRMParams.Uri)) {
             if ($null -eq $InvokeRestMethodParameters) {

--- a/source/public/Get-EasitGOItem.ps1
+++ b/source/public/Get-EasitGOItem.ps1
@@ -184,7 +184,9 @@ function Get-EasitGOItem {
         [Parameter(ParameterSetName='SeparateObjects')]
         [Switch]$FlatReturnObject,
         [Parameter()]
-        [System.Collections.Hashtable]$ConvertToJsonParameters
+        [System.Collections.Hashtable]$ConvertToJsonParameters,
+        [Parameter()]
+        [Switch]$WriteBody
     )
     begin {
         Write-Verbose "$($MyInvocation.MyCommand) initialized"
@@ -237,6 +239,13 @@ function Get-EasitGOItem {
             $baseRMParams.Body = New-GetEasitGOItemsRequestBody @newGetEasitGOItemsRequestBodyParams
         } catch {
             throw $_
+        }
+        if ($WriteBody) {
+            try {
+                Write-StringToFile -InputString $baseRMParams.Body -FilenamePrefix 'GetEasitGOItem'
+            } catch {
+                Write-Warning $_
+            }
         }
         if ($PSCmdlet.ShouldProcess($baseRMParams.Uri)) {
             if ($null -eq $InvokeRestMethodParameters) {

--- a/source/public/Send-ToEasitGO.ps1
+++ b/source/public/Send-ToEasitGO.ps1
@@ -120,7 +120,9 @@ function Send-ToEasitGO {
         [Alias('irmParams')]
         [System.Collections.Hashtable]$InvokeRestMethodParameters,
         [Parameter()]
-        [System.Collections.Hashtable]$ConvertToJsonParameters
+        [System.Collections.Hashtable]$ConvertToJsonParameters,
+        [Parameter()]
+        [Switch]$WriteBody
     )
     begin {
         Write-Verbose "$($MyInvocation.MyCommand) initialized"
@@ -187,6 +189,13 @@ function Send-ToEasitGO {
                     $baseRMParams.Body = New-PostEasitGOItemRequestBody @newPostEasitGOItemsRequestBodyParams
                 } catch {
                     throw $_
+                }
+                if ($WriteBody) {
+                    try {
+                        Write-StringToFile -InputString $baseRMParams.Body -FilenamePrefix 'SendToEasitGO'
+                    } catch {
+                        Write-Warning $_
+                    }
                 }
                 Write-Information "Sending $SendInBatchesOf items wih start at item $IDStart in array"
                 if ($null -eq $InvokeRestMethodParameters) {

--- a/tests/function/Write-StringToFile.Tests.ps1
+++ b/tests/function/Write-StringToFile.Tests.ps1
@@ -1,0 +1,46 @@
+BeforeAll {
+    try {
+        $getEnvSetPath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSCommandPath -Parent) -Parent) -ChildPath 'getEnvironmentSetting.ps1'
+        . $getEnvSetPath
+        $envSettings = Get-EnvironmentSetting -Path $PSCommandPath
+    } catch {
+        throw $_
+    }
+    if (Test-Path $envSettings.CodeFilePath) {
+        . $envSettings.CodeFilePath
+    } else {
+        Write-Output "Unable to locate code file ($($envSettings.CodeFilePath)) to test against!" -ForegroundColor Red
+    }
+    function Out-File {
+        param (
+            [Parameter(ValueFromPipeline)]
+            [String]$String,
+            [Parameter()]
+            [String]$FilePath,
+            [Parameter()]
+            [String]$Encoding,
+            [Parameter()]
+            [Switch]$Force
+        )
+    }
+}
+Describe "Write-StringToFile" -Tag 'function','private' {
+    It 'should have a parameter named InputString that accepts a string' {
+        Get-Command "$($envSettings.CommandName)" | Should -HaveParameter InputString -Type [System.String]
+    }
+    It 'should have a parameter named FilenamePrefix that accepts a string' {
+        Get-Command "$($envSettings.CommandName)" | Should -HaveParameter FilenamePrefix -Type [System.String]
+    }
+    It 'help section should have a SYNOPSIS' {
+        ((Get-Help "$($envSettings.CommandName)" -Full).SYNOPSIS).Length | Should -BeGreaterThan 0
+    }
+    It 'help section should have a DESCRIPTION' {
+        ((Get-Help "$($envSettings.CommandName)" -Full).DESCRIPTION).Length | Should -BeGreaterThan 0
+    }
+    It 'help section should have EXAMPLES' {
+        ((Get-Help "$($envSettings.CommandName)" -Full).EXAMPLES).Length | Should -BeGreaterThan 0
+    }
+    It 'should not throw' {
+        {Write-StringToFile -InputString 'bodytowritetofile' -FilenamePrefix 'SendToEasitGO'} | Should -Not -Throw
+    }
+}

--- a/tests/module/Get-EasitGODatasource.Tests.ps1
+++ b/tests/module/Get-EasitGODatasource.Tests.ps1
@@ -58,4 +58,7 @@ Describe "Get-EasitGODatasource" -Tag 'module' {
         $output = Get-EasitGODatasource -Url $url -Apikey $api -ModuleId 1001 -ReturnAsSeparateObjects -WhatIf
         $output | Should -BeNullOrEmpty
     }
+    It 'should write body to file when -WriteBody is used' {
+        $output = Get-EasitGODatasource -Url $url -Apikey $api -ModuleId 1001 -ReturnAsSeparateObjects -WriteBody
+    }
 }

--- a/tests/module/Get-EasitGOItem.Tests.ps1
+++ b/tests/module/Get-EasitGOItem.Tests.ps1
@@ -105,4 +105,7 @@ Describe "Get-EasitGOItem" -Tag 'module' {
         $output = Get-EasitGOItem -Url $url -Apikey $api -ImportViewIdentifier $ImportViewIdentifier -ReturnAsSeparateObjects -WhatIf
         $output | Should -BeNullOrEmpty
     }
+    It 'should write body to file when -WriteBody is used' {
+        $output = Get-EasitGOItem -Url $url -Apikey $api -ImportViewIdentifier $ImportViewIdentifier -ReturnAsSeparateObjects -WriteBody
+    }
 }

--- a/tests/module/Send-ToEasitGO.Tests.ps1
+++ b/tests/module/Send-ToEasitGO.Tests.ps1
@@ -97,4 +97,7 @@ Describe "Send-ToEasitGO" -Tag 'module' {
         $output = Send-ToEasitGO @sendItemParams -Item $1000Items -SendInBatchesOf 75 -WhatIf
         $output | Should -BeNullOrEmpty
     }
+    It 'should write body to file when -WriteBody is used' {
+        $output = Send-ToEasitGO @sendItemParams -Item $1000Items -SendInBatchesOf 75 -WriteBody
+    }
 }


### PR DESCRIPTION
This PR gives the user a new parameter, 'Write-Body'.
If the parameter is used, the request body will be written to a file the current directory.

Added to the following functions:
* Get-EasitGODatasource
* Get-EasitGOItem
* Send-ToEasitGO